### PR TITLE
MDE/KFE-74

### DIFF
--- a/app/back_end/requirements.txt
+++ b/app/back_end/requirements.txt
@@ -29,7 +29,6 @@ requests~=2.32.3
 selenium~=4.25.0
 simple-websocket~=1.0.0
 spliceai
-tensorflow
 Werkzeug~=3.0.3
 wsproto~=1.2.0
 zope.event~=5.0

--- a/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/downloadGroupButtons.tsx
+++ b/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/downloadGroupButtons.tsx
@@ -13,7 +13,16 @@ export interface DownloadGroupButtonsProps {}
 export const DownloadGroupButtons: React.FC<DownloadGroupButtonsProps> = () => {
   const { blockedStateUpdate } = useStatusContext();
   const { fileTree } = useWorkspaceContext();
-  const { saveTo, saveToErrorStateUpdate, override, gene } = useToolbarContext();
+  const { saveTo, saveToStateUpdate, saveToErrorStateUpdate, override, gene } = useToolbarContext();
+
+  const handleDownloadAllClick = useCallback(async () => {
+    saveToStateUpdate(defaultSaveTo);
+    await handleDownloadLovdClick();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await handleDownloadClinvarClick();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await handleDownloadGnomadClick();
+  }, [gene]);
 
   const handleDownloadLovdClick = useCallback(async () => {
     blockedStateUpdate(true);
@@ -95,6 +104,12 @@ export const DownloadGroupButtons: React.FC<DownloadGroupButtonsProps> = () => {
 
   const buttons: ToolbarGroupItemProps[] = useMemo(
     () => [
+      {
+        group: 'download',
+        icon: DownloadIcon,
+        label: 'Download All',
+        onClick: handleDownloadAllClick,
+      },
       {
         group: 'download',
         icon: DownloadIcon,

--- a/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/mergeGroupButtons.tsx
+++ b/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/mergeGroupButtons.tsx
@@ -26,6 +26,7 @@ export const MergeGroupButtons: React.FC<MergeGroupButtonsProps> = () => {
   } = useToolbarContext();
 
   const mergeAllClick = useCallback(async () => {
+    lovdErrorStateUpdate('');
     clinvarErrorStateUpdate('');
     gnomadErrorStateUpdate('');
 

--- a/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/mergeGroupButtons.tsx
+++ b/app/front_end/src/features/editor/components/toolbarView/toolbarGroupButtons/mergeGroupButtons.tsx
@@ -25,6 +25,41 @@ export const MergeGroupButtons: React.FC<MergeGroupButtonsProps> = () => {
     gnomadErrorStateUpdate,
   } = useToolbarContext();
 
+  const mergeAllClick = useCallback(async () => {
+    clinvarErrorStateUpdate('');
+    gnomadErrorStateUpdate('');
+
+    if (!lovdFile) lovdErrorStateUpdate('Please select a LOVD file');
+    if (!clinvarFile) clinvarErrorStateUpdate('Please select a ClinVar file');
+    if (!gnomadFile) gnomadErrorStateUpdate('Please select a gnomAD file');
+    if (!lovdFile || !clinvarFile || !gnomadFile) return;
+
+    blockedStateUpdate(true);
+
+    try {
+      const timestamp = generateTimestamp();
+      const savePath = saveTo !== defaultSaveTo ? saveTo.id : findUniqueFileName(fileTree, `all_merged_${timestamp}.csv`);
+      if (getFileExtension(savePath) !== 'csv') {
+        saveToErrorStateUpdate('Select .csv');
+        return
+      }
+
+      await axios.get(`${Endpoints.WORKSPACE_MERGE}/all/${savePath}`, {
+        params: {
+          override,
+          "lovdFile": lovdFile.id,
+          "clinvarFile": clinvarFile.id,
+          "gnomadFile": gnomadFile.id,
+        },
+      });
+    } catch (error) {
+      console.error('Error merging all files:', error);
+    } finally {
+      blockedStateUpdate(false);
+    }
+
+  }, [saveTo, override, lovdFile, clinvarFile, gnomadFile]);
+
   const mergeLovdAndGnomadClick = useCallback(async () => {
     clinvarErrorStateUpdate('');
 
@@ -89,6 +124,12 @@ export const MergeGroupButtons: React.FC<MergeGroupButtonsProps> = () => {
 
   const buttons: ToolbarGroupItemProps[] = useMemo(
     () => [
+      {
+        group: 'merge',
+        icon: MergeTypeIcon,
+        label: 'Merge All',
+        onClick: mergeAllClick,
+      },
       {
         group: 'merge',
         icon: MergeTypeIcon,


### PR DESCRIPTION
# Initial (2025-01-22)
- [MDE/KFE-74 unified download](https://github.com/mantvydasdeltuva/kath/commit/e8dfcaab31df01829aeb20652e62ceda0ff3679f) Now it's available to download all databases with one action.
- [MDE/KFE-74 unified merge ui](https://github.com/mantvydasdeltuva/kath/commit/8dfa59b6c5bee9070884a9113d3d59077929888b) Implemented button for all  databases merge.
- [MDE/KFE-74 unified download endpoint](https://github.com/mantvydasdeltuva/kath/commit/4019db600ec2d8e8ae93d92108b8fb161ce67fd3) Introduced backbone of back-end endpoint for all databases merge.
# Changes (2025-01-23)
- [MDE/KFE-74 added error reset on lovd](https://github.com/mantvydasdeltuva/kath/pull/16/commits/7330801e48db44e8b6e12b3fe2ac48ad89c92289)