### PR TITLE
VLE/spliceai_cadd_delete_limits

### DIFF
--- a/app/back_end/src/tools/__init__.py
+++ b/app/back_end/src/tools/__init__.py
@@ -1,19 +1,10 @@
-"""CADD and SpliceAI Tool Package Initialization."""
+"""Tools Package Initialization."""
 
 from .cadd import (
-    BadResponseException,
-    DownloadError,
-    fetch_cadd_scores,
-    evaluate_cadd_score,
-    prepare_data_cadd,
-    add_cadd_eval_column,
+    cadd_pipeline,
 )
 
 from .spliceai import (
-    SpliceAIError,
-    write_vcf,
-    run_spliceai,
-    parse_spliceai_vcf,
     add_spliceai_eval_columns,
 )
 
@@ -23,17 +14,8 @@ from .revel import (
 
 __all__ = [
     # CADD related exports
-    "BadResponseException",
-    "DownloadError",
-    "fetch_cadd_scores",
-    "evaluate_cadd_score",
-    "prepare_data_cadd",
-    "add_cadd_eval_column",
+    "cadd_pipeline",
     # SpliceAI related exports
-    "SpliceAIError",
-    "write_vcf",
-    "run_spliceai",
-    "parse_spliceai_vcf",
     "add_spliceai_eval_columns",
     # Revel related exports
     "main_revel_pipeline",

--- a/app/back_end/src/tools/cadd.py
+++ b/app/back_end/src/tools/cadd.py
@@ -1,166 +1,343 @@
 """ Module provides interface to web APIs of CADD tool. """
-import argparse
-import requests
+import os
+import time
+import gzip
+import shutil
+import re
+from datetime import datetime
+
 import pandas as pd
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 
 
-class BadResponseException(Exception):
-    """Custom exception for bad responses."""
-
-
-class DownloadError(Exception):
-    """Custom exception for download errors."""
-
-
-def fetch_cadd_scores(cadd_version, chromosome, start, end=None):
+def gunzip_file(file_path:str):
     """
-    Fetches CADD (Combined Annotation Dependent Depletion)
-    scores for either a single SNV or a range of genomic positions.
+    Uncompresses a file from .gz format.
 
-    :param str cadd_version: Version of the CADD model used, e.g., "v1.3" or "GRCh38-v1.7".
-    :param int chromosome: Chromosome number where the SNV or genomic region is located.
-    :param int start: Genomic start position (or single position for SNV) of the region.
-    :param int end: (Optional) Genomic end position of the region.
-    If not provided, fetches a single SNV.
-    :return: A dictionary containing CADD scores and annotations
-    for the specified SNV or region, or None if an
-    error occurs.
+    This function takes a file at the given file path and uncompresses it 
+    from a .gz file by reading the gzipped file and extracting it to a 
+    uncompressed version.
+
+    Args:
+        file_path (str): The path of the file to be uncompressed.
+
+    Returns:
+        str: The path to the newly gunzipped file.
     """
+    with gzip.open(file_path, 'rb') as f_in:
+        with open(file_path[:-3], 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
-    if end:
-        url = f"https://cadd.gs.washington.edu/api/v1.0/{cadd_version}/{chromosome}:{start}-{end}"
-    else:
-        url = f"https://cadd.gs.washington.edu/api/v1.0/{cadd_version}/{chromosome}:{start}"
 
+def gzip_file(file_path: str):
+    """
+    Compresses a file into a .gz format.
+
+    This function takes a file at the given file path and compresses it 
+    into a .gz file by reading the original file and writing it to a 
+    gzipped version.
+
+    Args:
+        file_path (str): The path of the file to be compressed.
+
+    Returns:
+        str: The path to the newly gzipped file.
+    """
+    gzipped_file_path = f"{file_path}.gz"
+
+    with open(file_path, 'rb') as f_in:
+        with gzip.open(gzipped_file_path, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+    return gzipped_file_path
+
+
+def parse_variant(variant_str):
+    """
+    Parses a variant string and extracts chromosome, position, reference, and alternative alleles.
+
+    The function takes a variant string in the format of `chrom-pos-ref-alt` (e.g., `1-123-A-G`), 
+    and splits it into the individual components. If the string contains only chromosome and position 
+    (e.g., `1-123`), it will assume reference and alternative alleles as missing (represented by `"."`).
+
+    Args:
+        variant_str (str): The variant string to be parsed, typically in the format `chrom-pos-ref-alt`.
+
+    Returns:
+        tuple: A tuple containing:
+            - chrom (str): The chromosome part of the variant string.
+            - pos (str): The position part of the variant string.
+            - ref (str): The reference allele (or `"."` if not provided).
+            - alt (str): The alternative allele (or `"."` if not provided).
+
+    Example:
+        parse_variant("1-123-A-G")  -> ('1', '123', 'A', 'G')
+        parse_variant("1-123")      -> ('1', '123', '.', '.')
+    """
     try:
-        response = requests.get(url, timeout=30)
-        if response.status_code == 200:
-            data = response.json()
-            return data
-        raise BadResponseException(
-            f"Error: Received status code {response.status_code} - "
-            f"{response.reason}: {response.text}")
+        chrom, pos, ref, alt = variant_str.split("-")
+        return chrom, pos, ref, alt
+    except ValueError:
+        chrom, pos, _ = variant_str.split("-")
+        return chrom, pos, ".", "."
+    except AttributeError:
+        return ".", ".", ".", "."
+    
 
-    except requests.exceptions.Timeout as exc:
-        raise DownloadError(
-            "Error: Timeout occurred while trying to reach the server. "
-            "Please check your internet connection or the server status.") from exc
-
-    except requests.exceptions.RequestException as req_err:
-        raise DownloadError(
-            f"Error: An unexpected error occurred while making the request. "
-            f"Details: {req_err}") from req_err
-
-    except ValueError as exc:
-        raise BadResponseException(
-            "Error: Invalid JSON format in response. "
-            "Please ensure the server is returning valid JSON.") from exc
-
-
-def evaluate_cadd_score(row, cadd_version="GRCh38-v1.7"):
+def extract_job_id(url:str):
     """
-    Evaluates the CADD score for a given row in the
-     DataFrame and returns the highest PHRED score evaluation.
-    Handles cases where the response is malformed or incomplete.
+    Extracts the job ID from a given URL.
 
-    :param row: A row from the DataFrame.
-    :param str cadd_version: The CADD version to use for fetching the score.
-    :return: A string indicating the evaluation result based
-     on the highest PHRED score, or an error message.
+    This function searches for a 32-character hexadecimal string (typically used as a job ID)
+    in the provided URL. 
+    The job ID is expected to be in the format `_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+    where `x` is a hexadecimal character (a-f, 0-9).
+
+    Args:
+        url (str): The URL string from which the job ID will be extracted.
+
+    Returns:
+        str or None: The extracted job ID as a string (without the leading underscore), 
+        or None if no valid job ID is found.
+
     """
-    position = row.loc["hg38_gnomad_format"]
+    match = re.search(r'_([a-f0-9]{32})', url)
+    if match:
+        return match.group(0)
+    return None
 
-    if  pd.isna(position):
-        chromosome = row.loc["Chromosome_gnomad"]
-        position= row.loc["Position_gnomad"]
-    else:
-        chromosome = row.loc["hg38_gnomad_format"].split('-')[0]
-        position = row.loc["hg38_gnomad_format"].split('-')[1]
 
-    score = fetch_cadd_scores(cadd_version, chromosome, position)
+def get_cadd_scores_file(file_path:str):
+    """
+    Processes a given VCF file to retrieve CADD scores.
 
-    if score is None or not isinstance(score, list) or len(score) < 2:
-        return "CADD score unavailable" #intended
+    This function renames the input file with a timestamp, sets up a 
+    headless Firefox WebDriver with appropriate download preferences, 
+    and downloads CADD scores from an online source. The downloaded 
+    file is then extracted and cleaned up.
 
+    Args:
+        file_path (str): The path to the input VCF file.
+
+    Returns:
+        str: The path to the processed CADD scores TSV file.
+
+    Steps:
+        1. Rename the input file to include a timestamp.
+        2. Configure a headless Firefox WebDriver for automated download.
+        3. Download CADD scores using the provided VCF file.
+        4. Extract the downloaded GZ file and remove the compressed version.
+        5. Return the path to the extracted CADD scores TSV file.
+    """
+   
+    download_dir = os.path.dirname(file_path)
+
+    options = webdriver.FirefoxOptions()
+    options.add_argument("--headless")
+    
+    if not os.path.exists(download_dir):
+        os.makedirs(download_dir)
+
+    options.set_preference("browser.download.folderList", 2)
+    options.set_preference("browser.download.manager.showWhenStarting", False)
+    options.set_preference("browser.download.dir", download_dir)
+    options.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/gzip")
+
+    driver = webdriver.Firefox(options=options)
+
+    job_id = download_cadd_scores(driver=driver,vcf_file_path=file_path)
+
+    downloaded_file = os.path.join(download_dir, f"GRCh38-v1.7{job_id}.tsv.gz")
+    gunzip_file(downloaded_file)
+    os.remove(downloaded_file)
+
+    return os.path.join(download_dir, f"GRCh38-v1.7{job_id}.tsv")
+
+
+def download_cadd_scores(driver:webdriver.Firefox,vcf_file_path:str):
+    """
+    Downloads CADD (Combined Annotation-Dependent Depletion) scores for a given VCF file.
+
+    This function automates the process of uploading a VCF file to the CADD web service, 
+    checking the job status, and downloading the resulting CADD scores file. It uses Selenium 
+    WebDriver to interact with the CADD website, waits for the job to finish, and retrieves 
+    the resulting file.
+
+    Args:
+        driver (webdriver.Firefox): The WebDriver instance to interact with the browser.
+        vcf_file_path (str): The local path to the VCF file to be uploaded to the CADD service.
+
+    Returns:
+        str: job_id of processed file from CADD web-server.
+    
+    Raises:
+        TimeoutException: If the job status link or finished file link cannot be found within the 
+                          expected time frame.
+    """
     try:
-        score_df = pd.DataFrame(score[1:], columns=score[0])
-    except (IndexError, ValueError) as e:
-        raise ValueError(f"Error processing CADD score: {e}") from e
+        driver.get("https://cadd.bihealth.org/score")
 
-    if "PHRED" not in score_df.columns:
-        raise KeyError("PHRED score unavailable")
+        file_input = WebDriverWait(driver, 20).until(
+            EC.presence_of_element_located((By.NAME, "file"))
+        )
+        file_input.send_keys(os.path.abspath(vcf_file_path))
 
-    sorted_df = score_df.sort_values(by="PHRED", ascending=False)
-    highest_score_row = sorted_df.iloc[0]
+        submit_button = driver.find_element(By.XPATH, '//input[@type="submit"]')
+        submit_button.click()
 
-    return highest_score_row.loc['PHRED']
+        WebDriverWait(driver, 20).until(EC.url_contains("/upload"))
+
+        try:
+            finished_link = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/static/finished/")]'))
+            )
+            job_id = extract_job_id(finished_link.get_attribute("href"))
+            finished_link.click()
+            time.sleep(5)
+        except:
+            try:
+                check_avail_link = WebDriverWait(driver, 30).until(
+                    EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/check_avail/")]'))
+                )
+                job_url = check_avail_link.get_attribute("href")
+                job_id = extract_job_id(job_url)
+            except TimeoutException:
+                raise TimeoutException("CADD:Could not find the job status link (/check_avail/).")
+
+            driver.get(job_url)
+
+            while True:
+                driver.refresh()
+                try:
+                    finished_link = WebDriverWait(driver, 10).until(
+                    EC.presence_of_element_located((By.XPATH, '//a[contains(@href, "/static/finished/")]'))
+                    )
+                    job_id = extract_job_id(finished_link.get_attribute("href"))
+                    finished_link.click()
+                    time.sleep(5)
+                    break
+                except:
+                    time.sleep(60)
+    finally:
+        driver.quit()
+        return job_id
 
 
-def prepare_data_cadd(data:pd.DataFrame):
+def write_vcf(dataframe:pd.DataFrame, output_filepath:str) -> str:
     """
-    Prepares the DataFrame for CADD evaluation by extracting chromosome
-    and position from the 'variant_id_gnomad' column.
+    Writes a VCF (Variant Call Format) file without header
+    from the given DataFrame.
 
-    :param data: DataFrame.
-    :return: Updated DataFrame with 'Chromosome_gnomad' and 'Position_gnomad' columns.
+    This function extracts specific variant information
+    from a pandas DataFrame and writes it to a VCF file.
+    For each row, the function extracts the first valid variant value 
+    found in these columns, parses it, and writes the corresponding VCF line.
+
+    Args:
+        dataframe (pd.DataFrame): The DataFrame containing the variant data.
+        output_filepath (str): The path where the VCF file will be saved.
+
+    Returns:
+        str: The file path where the VCF file has been written.
     """
-    if 'variant_id_gnomad' not in data.columns:
-        raise KeyError("The 'variant_id_gnomad' column is missing from the DataFrame.")
+    with open(output_filepath, 'w') as f:
+        variant_columns = ["hg38_gnomad_format", "variant_id_gnomad","variant_id", "hg38_ID_clinvar"]
+        for _, row in dataframe.iterrows():
+            variant_value = None
+            for col in variant_columns:
+                if col in row and pd.notna(row[col]) and row[col]!="?":
+                    variant_value = row[col]
+                    break
+            chrom, pos, ref, alt = parse_variant(variant_value)
+            vcf_line = f"{chrom}\t{pos}\t.\t{ref}\t{alt}\n"
+            f.write(vcf_line) 
+    return output_filepath  
+
+
+def parse_tsv(tsv_file_path: str, vcf_file_path: str):
+    """
+    Parses a TSV (Tab-Separated Values) file to extract PHRED scores.
+
+    This function reads a TSV file, skips comment lines (lines starting with `#`),
+    and extracts PHRED scores from the sixth column (index 5) based on variant
+    positions and alleles found in the VCF file. If a corresponding value is not
+    found, "CADD score unavailable" is stored.
+
+    Args:
+        tsv_file_path (str): The path to the TSV file.
+        vcf_file_path (str): The path to the VCF file.
+
+    Returns:
+        dict: A dictionary mapping VCF variants (chrom, pos, ref, alt) to PHRED scores,
+              or "CADD score unavailable" if no match is found.
+
+    Raises:
+        ValueError: If an error occurs while reading or parsing the file.
+    """
     try:
-        split_data = data['variant_id_gnomad'].str.split('-', n=2, expand=True)
-        data[['Chromosome_gnomad', 'Position_gnomad']] = split_data[[0, 1]]
-    except ValueError as e:
-        raise ValueError(
-            f"Error processing 'variant_id_gnomad': {e}. "
-            f"This may be due to unexpected formatting or delimiters.")
+        tsv_data = {}
+        with open(tsv_file_path, 'r', encoding='utf-8') as tsv:
+            for line in tsv:
+                if line.startswith('#'):
+                    continue
+                columns = line.strip().split('\t')
+                key = f"{columns[0]}:{columns[1]}:{columns[2]}:{columns[3]}"
+                tsv_data[key] = columns[5]
 
-    data['Chromosome_gnomad'] = data['Chromosome_gnomad'].astype('Int64')
-    data['Position_gnomad'] = data['Position_gnomad'].astype('Int64')
+        phred_scores = []
+        with open(vcf_file_path, 'r', encoding='utf-8') as vcf:
+            for line in vcf:
+                columns = line.strip().split('\t')
+                if len(columns) < 5:
+                    phred_scores.append("CADD score unavailable")
+                    continue
+                key = f"{columns[0]}:{columns[1]}:{columns[3]}:{columns[4]}"
+                phred_scores.append(tsv_data.get(key, "CADD score unavailable"))
+        
+        return phred_scores
+    
+    except Exception as e:
+        raise ValueError(f"CADD: Error parsing files {tsv_file_path} or {vcf_file_path}: {e}") from e
 
-    if 'Chromosome_gnomad' not in data.columns or 'Position_gnomad' not in data.columns:
-        raise RuntimeError("The columns 'Chromosome_gnomad' or 'Position_gnomad' "
-                           "were not created successfully.")
-    return data
 
-
-def add_cadd_eval_column(data:pd.DataFrame, cadd_version="GRCh38-v1.7"):
+def cadd_pipeline(dataframe:pd.DataFrame,vcf_file_path:str)->pd.DataFrame:
     """
-    Adds a column 'cadd_eval' to the DataFrame based on CADD score evaluations for each row.
+    Executes the CADD (Combined Annotation Dependent Depletion) scoring pipeline.
 
-    :param data: The merged DataFrame with genomic data.
-    :param str cadd_version: The version of the CADD model to use for score fetching.
-    :return: The updated DataFrame with the 'cadd_eval' column.
+    This function processes a given dataframe by:
+    1. Writing it to a VCF file.
+    2. Compressing the VCF file.
+    3. Submitting it to the CADD server to retrieve PHRED-like scores.
+    4. Parsing the downloaded scores and appending them to the original dataframe.
+
+    Args:
+        dataframe (pd.DataFrame): The input dataframe containing variant data.
+        vcf_file_path (str): The file path where the VCF file will be stored.
+
+    Returns:
+        pd.DataFrame: The original dataframe with an additional column "PHRED_cadd"
+                      containing the CADD scores.
+
+    Steps:
+        1. Create a copy of the input dataframe.
+        2. Write the dataframe to a VCF file.
+        3. Compress the VCF file using gzip.
+        4. Retrieve CADD scores for the compressed VCF file.
+        5. Parse the downloaded scores and append them to the dataframe.
+        6. Remove the temporary CADD TSV file.
+        7. Return the dataframe with the appended CADD scores.
     """
-    data = prepare_data_cadd(data)
-    try:
-        data["cadd_eval(PHRED)"] = data.apply(evaluate_cadd_score, axis=1, cadd_version=cadd_version)
-    except ValueError as e:
-        raise ValueError(
-            f"Error occurred while applying 'evaluate_cadd_score': {e}. "
-            f"This may be due to incorrect data types or NaN values in the input DataFrame.")
-    if "cadd_eval(PHRED)" not in data.columns:
-        raise RuntimeError("CADD evaluation column 'cadd_eval(PHRED)' was not created successfully.")
-
-    return data
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Fetch CADD scores for genomic positions.")
-    parser.add_argument("version", help="CADD version, e.g., 'v1.3' or 'GRCh38-v1.7'")
-    parser.add_argument("chromosome", type=int, help="Chromosome number")
-    parser.add_argument("--position", type=int, help="Genomic position (for single SNV)")
-    parser.add_argument("--start", type=int,
-                        help="Genomic start position (for a range of positions)")
-    parser.add_argument("--end", type=int, help="Genomic end position (for a range of positions)")
-
-    args = parser.parse_args()
-
-    if args.position:
-        result = fetch_cadd_scores(args.version, args.chromosome, args.position)
-        print(result)
-    elif args.start and args.end:
-        result = fetch_cadd_scores(args.version, args.chromosome, args.start, args.end)
-        print(result)
-    else:
-        print("Please provide either '--position' for single SNV \
-              or '--start' and '--end' for a range of positions.")
+    data_copy=dataframe.copy()
+    input_vcf_file=write_vcf(dataframe=data_copy,output_filepath=vcf_file_path)
+    gzipped_file_path = gzip_file(input_vcf_file)
+    cadd_tsv_file=get_cadd_scores_file(gzipped_file_path)
+    os.remove(gzipped_file_path)
+    scores = parse_tsv(tsv_file_path=cadd_tsv_file,vcf_file_path=input_vcf_file)
+    scores_df = pd.DataFrame(scores)
+    scores_df.columns = ["PHRED_cadd"]
+    data_copy = pd.concat([data_copy,scores_df], axis=1)
+    return data_copy


### PR DESCRIPTION
# Initial (2025-02-21)
- [VLE/spliceai_cadd_fix](https://github.com/mantvydasdeltuva/kath/commit/a5052ad225a356ca289c559d1c55b88a35da721d)

1. Light refactoring of spliceai logic(deleting DataFrame size output limit) - requires speed up using GPU version of tensorflow
2. Refactoring of cadd implementation( moving from using CADD API(not designed for thousands of rows) to uploading VCF file to CADD German based web-server and retrieving results from gzipped tsv file) - possibility for speed up by submitting not one big VCF file, but several files at once, retrieving submitted jobs, and merging them into one output VCF file 
